### PR TITLE
Enable term name enclusure using quotes and other improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.niroma.net
 Requires at least: 3.0.1
 Tested up to: 5.1.1
 Requires PHP: 5.6.0
-Stable tag: 1.1.4
+Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/inc/admin/class-admin.php
+++ b/inc/admin/class-admin.php
@@ -179,7 +179,7 @@ class Admin {
 								$result = wp_insert_term( $cat_name, $taxonomyActive, array('slug' => $cat_slug) );
 								if ( ! is_wp_error( $result ) ) {
 									$parent_id = isset( $result['term_id'] ) ? $result['term_id'] : '';
-									$rootCategories[] = array('id' => $parent_id, 'name' => $cat_name);
+									$rootCategories[$cat_name] = $parent_id;
 									$countSuccess++;
 								} else $countErrors++;
 							}


### PR DESCRIPTION
Following the code fix I left in this support [thread](https://wordpress.org/support/topic/wrong-parent-selected-with-some-characters/#post-12270382), I found your github repo and did a PR.